### PR TITLE
Validation Error時の詳細をKintone::KintoneErrorから取り出せるように

### DIFF
--- a/lib/kintone/kintone_error.rb
+++ b/lib/kintone/kintone_error.rb
@@ -1,10 +1,11 @@
 class Kintone::KintoneError < StandardError
-  attr_reader :message_text, :id, :code, :http_status
+  attr_reader :message_text, :id, :code, :http_status, :errors
 
   def initialize(messages, http_status)
     @message_text = messages['message']
     @id = messages['id']
     @code = messages['code']
+    @errors = messages['errors']
     @http_status = http_status
     super(format('%s [%s] %s(%s)', @http_status, @code, @message_text, @id))
   end

--- a/spec/kintone/kintone_error_spec.rb
+++ b/spec/kintone/kintone_error_spec.rb
@@ -7,16 +7,87 @@ describe Kintone::KintoneError do
   describe '#message' do
     subject { target.message }
 
-    let(:messages) do
-      {
-        'message' => '不正なJSON文字列です。',
-        'id' => '1505999166-897850006',
-        'code' => 'CB_IJ01'
-      }
+    context '不正なJSONの場合' do
+      let(:messages) do
+        {
+          'message' => '不正なJSON文字列です。',
+          'id' => '1505999166-897850006',
+          'code' => 'CB_IJ01'
+        }
+      end
+
+      let(:http_status) { 500 }
+
+      it { is_expected.to eq '500 [CB_IJ01] 不正なJSON文字列です。(1505999166-897850006)' }
+
+      describe '#message_text' do
+        subject { target.message_text }
+        it { is_expected.to eq '不正なJSON文字列です。' }
+      end
+
+      describe '#id' do
+        subject { target.id }
+        it { is_expected.to eq '1505999166-897850006' }
+      end
+
+      describe '#code' do
+        subject { target.code }
+        it { is_expected.to eq 'CB_IJ01' }
+      end
+
+      describe '#http_status' do
+        subject { target.http_status }
+        it { is_expected.to eq 500 }
+      end
+
+      describe '#errors' do
+        subject { target.errors }
+        it { is_expected.to be_nil }
+      end
     end
 
-    let(:http_status) { 500 }
+    context 'Validation Errorの場合' do
+      let(:messages) do
+        {
+          'message' => '入力内容が正しくありません。',
+          'id' => '1505999166-836316825',
+          'code' => 'CB_VA01',
+          'errors' => {
+            'record.field_code.value' => {
+              'messages' => ['必須です。']
+            }
+          }
+        }
+      end
 
-    it { is_expected.to eq '500 [CB_IJ01] 不正なJSON文字列です。(1505999166-897850006)' }
+      let(:http_status) { 400 }
+
+      it { is_expected.to eq '400 [CB_VA01] 入力内容が正しくありません。(1505999166-836316825)' }
+
+      describe '#message_text' do
+        subject { target.message_text }
+        it { is_expected.to eq '入力内容が正しくありません。' }
+      end
+
+      describe '#id' do
+        subject { target.id }
+        it { is_expected.to eq '1505999166-836316825' }
+      end
+
+      describe '#code' do
+        subject { target.code }
+        it { is_expected.to eq 'CB_VA01' }
+      end
+
+      describe '#http_status' do
+        subject { target.http_status }
+        it { is_expected.to eq 400 }
+      end
+
+      describe '#errors' do
+        subject { target.errors['record.field_code.value']['messages'].first }
+        it { is_expected.to eq '必須です。' }
+      end
+    end
   end
 end


### PR DESCRIPTION
はじめまして。いつも便利に使わせて頂いています。

Kintone側にpostやputを送ったときのValidation Errorの詳細がKintone::KintoneErrorで取得する手段がなかったので追加してみました。
あまりpull request送ることがないものでいきなり送っていいのかどうかもよくわかってないのですが、もし宜しければ取り込んで頂けるとありがたいです。一応specも書いておきましたので。

必要な理由ですが、
```
    rescue Kintone::KintoneError => e
      Bugsnag.notify(e, errors: e.errors)
    end
```
といった感じでBugsnagに詳細を通知したいのです。