### PR TITLE
README: Fix example params and results for bulk request

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ api.records.delete(app, ids, revisions: revisions)
 ### <a name="bulk_request"> Bulk request
 
 ```ruby
-requests = {"requests" => [{"method" => "POST", ...}, {"method" => "PUT", ...}]}
-api.bulk.request(requests) # => {"results" => [...]}
+requests = [{"method" => "POST", ...}, {"method" => "PUT", ...}]
+api.bulk.request(requests) # => [...]
 ```
 
 ### <a name="file"> File


### PR DESCRIPTION
Thank you for useful Gem.
It seems that the requests key and the results key are unnecessary for Bulk Request. I fixed it.