### PR TITLE
X-Cybozu-Authorization のbase64エンコーディングを修正

### DIFF
--- a/lib/kintone/api.rb
+++ b/lib/kintone/api.rb
@@ -111,7 +111,7 @@ class Kintone::Api
 
   def build_headers(user, password)
     if password # パスワード認証
-      { 'X-Cybozu-Authorization' => Base64.encode64("#{user}:#{password}") }
+      { 'X-Cybozu-Authorization' => Base64.strict_encode64("#{user}:#{password}") }
     else # APIトークン認証
       { 'X-Cybozu-API-Token' => user }
     end


### PR DESCRIPTION
id/pwdが長くなってくると、base64エンコード結果の途中に改行コードが含まれてしまうため、正しく認証が行われませんでした。
`encode64`ではなく`strict_encode64`を利用するように修正し、動作を確認しました。

検討をお願いします。