### PR TITLE
add basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ api = Kintone::Api.new("example.cybozu.com", "Administrator", "cybozu")
 
 # Use token authentication
 api = Kintone::Api.new("example.cybozu.com", "authtoken")
+
+# Basic authentication
+api.basic_auth("username", "password")
 ```
 
 ### Supported API

--- a/lib/kintone/api.rb
+++ b/lib/kintone/api.rb
@@ -29,6 +29,11 @@ class Kintone::Api
     yield(@connection) if block_given?
   end
 
+  def basic_auth(name, password)
+      @connection.basic_auth(name, password)
+      self
+  end
+
   def get_url(command)
     BASE_PATH + (COMMAND % command)
   end

--- a/spec/kintone/api_spec.rb
+++ b/spec/kintone/api_spec.rb
@@ -563,4 +563,22 @@ describe Kintone::Api do
       it { is_expected.to be_a Faraday::ProxyOptions }
     end
   end
+
+  describe '#basic_auth' do
+    let(:domain) { 'www.example.com' }
+    let(:user) { 'Administrator' }
+    let(:password) { 'cybozu' }
+    let(:basic_auth_user) { 'user' }
+    let(:basic_auth_password) { 'password' }
+
+    context 'Basic認証' do
+      subject do
+        api.basic_auth(basic_auth_user, basic_auth_password)
+           .instance_variable_get(:@connection).headers['Authorization']
+      end
+      let(:api) { Kintone::Api.new(domain, user, password) }
+
+      it { is_expected.to match(/Basic \w+/) }
+    end
+  end
 end


### PR DESCRIPTION
Thanks to #11, we can use basic auth by customizing Faraday.connection. Since BasicAuthentication is provided by Kintone platform, it's worth to provide a method from the library. Otherwise, it should be documented like below at least.  I'm the one who could not figure out how to handle basic auth lol.

```
# Basic authentication
api = Kintone::Api.new("devhopjsm.cybozu.com", "token") do |connection|
     connection.basic_auth("user", "password")
end
```
