### PR TITLE
Avoid circular require: kintone/api.rb  <=>  kintone/api/guest.rb

### DIFF
--- a/lib/kintone/api/guest.rb
+++ b/lib/kintone/api/guest.rb
@@ -1,5 +1,4 @@
 require 'forwardable'
-require 'kintone/api'
 require 'kintone/command/accessor'
 
 class Kintone::Api


### PR DESCRIPTION
Requiring this gem emits "circular require" warning between kintone/api.rb and kintone/api/guest.rb, e.g.)

```
$ ruby -rkintone -wep
.../rubygems/core_ext/kernel_require.rb:83: warning: .../rubygems/core_ext/kernel_require.rb:83: warning: loading in progress, circular require considered harmful - .../gems/kintone-0.1.5/lib/kintone/api.rb
	from .../rubygems/core_ext/kernel_require.rb:147:in  `require'
	from .../rubygems/core_ext/kernel_require.rb:158:in  `rescue in require'
	from .../rubygems/core_ext/kernel_require.rb:158:in  `require'
	from .../gems/kintone-0.1.5/lib/kintone.rb:2:in  `<top (required)>'
	from .../rubygems/core_ext/kernel_require.rb:94:in  `require'
	from .../rubygems/core_ext/kernel_require.rb:94:in  `require'
	from .../gems/kintone-0.1.5/lib/kintone/api.rb:6:in  `<top (required)>'
	from .../rubygems/core_ext/kernel_require.rb:83:in  `require'
	from .../rubygems/core_ext/kernel_require.rb:83:in  `require'
	from .../gems/kintone-0.1.5/lib/kintone/api/guest.rb:2:in  `<top (required)>'
	from .../rubygems/core_ext/kernel_require.rb:83:in  `require'
	from .../rubygems/core_ext/kernel_require.rb:83:in  `require'
```

And here's a simple fix for that.