### PR TITLE
Update some dependencies to upgrade fraday and to work with newer Ruby

### DIFF
--- a/kintone.gemspec
+++ b/kintone.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.5'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3'
-  spec.add_development_dependency 'rubocop', '~> 0.44.1'
+  spec.add_development_dependency 'rubocop', '>= 0.44.1'
   spec.add_development_dependency 'webmock', '~> 2.3'
   spec.add_development_dependency 'rspec-parameterized', '~> 0.1.2'
   spec.add_development_dependency 'coveralls'

--- a/kintone.gemspec
+++ b/kintone.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'faraday', '>=0.9.2'
-  spec.add_runtime_dependency 'faraday_middleware', '>=0.10.0'
+  spec.add_runtime_dependency 'faraday', '>= 2'
+  spec.add_runtime_dependency 'faraday-multipart'
 
   spec.add_development_dependency 'bundler', '>= 1.5'
   spec.add_development_dependency 'rake'

--- a/kintone.gemspec
+++ b/kintone.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faraday', '>=0.9.2'
   spec.add_runtime_dependency 'faraday_middleware', '>=0.10.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.5'
+  spec.add_development_dependency 'bundler', '>= 1.5'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'rubocop', '~> 0.44.1'

--- a/lib/kintone/api.rb
+++ b/lib/kintone/api.rb
@@ -1,5 +1,5 @@
 require 'faraday'
-require 'faraday_middleware'
+require 'faraday/multipart'
 require 'base64'
 require 'json'
 require 'kintone/command/accessor'


### PR DESCRIPTION
Revised the version specifications of dependencies to upgrade Faraday to version 2 or later.

* Removed the dependency on faraday_middleware, which has been deprecated in Faraday 2, and switched to using faraday-multipart for multipart uploads.
* Made it possible to use a version of rubocop that is compatible with Ruby 3.2 and later.
  * As a result, many warnings are being issued, but we are postponing addressing them for now to suppress the diff.
* Also made it possible to use the new bundler.

--------

Faraday のバージョンを2以降にアップグレードさせるため、依存関係のバージョン指定を見直しました。

- Faraday 2系 でdeprecated になった faraday_middleware の依存を消し、マルチパートアップロードのために faraday-multipart を使うようにした
- Ruby 3.2 以降に対応しているバージョンの rubocop を使えるようにした
  - その結果、警告がたくさん出ていますが、diffを抑制するためにいったん対応は見送っています
- 新しいbundlerも使えるようにした